### PR TITLE
Remove setVisible for pop up behaviour

### DIFF
--- a/src/main/java/MovieAddWindow.java
+++ b/src/main/java/MovieAddWindow.java
@@ -64,7 +64,6 @@ public class MovieAddWindow extends JFrame{
         AppData.getInstance().addMovie(new Movie(title,duration,description,genre,imax,dolbyAtmos));
 
         previousWindow.refreshData();
-        previousWindow.setVisible(true);
         dispose();
     }
 
@@ -88,7 +87,6 @@ public class MovieAddWindow extends JFrame{
     }
 
     private void cancelButtonPerformed(ActionEvent e){
-        previousWindow.setVisible(true);
         dispose();
     }
 }

--- a/src/main/java/MovieManagerWindow.java
+++ b/src/main/java/MovieManagerWindow.java
@@ -55,7 +55,6 @@ public class MovieManagerWindow extends JFrame implements ManagerInterface<Movie
 
     private void addMovieButtonPerformed(ActionEvent e){
         new MovieAddWindow(this).setVisible(true);
-        setVisible(false);
     }
 
     private void editMovieButtonPerformed(ActionEvent e){


### PR DESCRIPTION
Eliminated redundant setVisible(true/false) calls when switching between MovieAddWindow and MovieManagerWindow to simplify window visibility management.